### PR TITLE
Setting official use tag to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here is an example YAML Fragment in the steps section of a build:
 ```yaml
     steps:
     - name: Deploy Build Assets from bin/ directory
-      uses: snxd/deploy-github-deploy-action@main
+      uses: snxd/deploy-github-deploy-action@v1
       with:
         working_directory: 'bin/'
         console_version: '6.1.2.51'


### PR DESCRIPTION
Putting the official action name to @v1 so I can tag this as a release and start pushing the setup-action stuff to main and become the pre-v2.